### PR TITLE
Update `market.browse` to make all params optional, rather than required.

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -14,7 +14,16 @@ type ScriptFailure = {
 type ScriptResponse<T = object> = ScriptSuccess<T> | ScriptFailure
 type ErrorScripts = Record<string, () => ScriptFailure>
 
-type Scriptor = Pick<Function, "name" | "call">;
+type AllOptional<T> = {
+	[K in keyof T]-?: {} extends Pick<T, K> ? true : false;
+}[keyof T] extends true ? true : false;
+
+type Scriptor<Args = unknown, Ret = unknown> = {
+	name: string,
+	call: AllOptional<Args> extends true
+		? (args?: Args) => Ret
+		: (args: Args) => Ret;
+};
 
 /*
 type Scriptor<Args = unknown, Ret = ScriptResponse> = {
@@ -854,7 +863,7 @@ type Highsec = Fullsec & PlayerHighsec & {
 		}) => (
 			Omit<UpgradeCore, keyof F | `rarity`> & F & {
 				[x: string]: null | boolean | number | string
-				rarity: UpgradeRarity
+				rarity: UpgradeRarityString
 			}
 		)[] | ScriptFailure)
 	}

--- a/env.d.ts
+++ b/env.d.ts
@@ -14,10 +14,14 @@ type ScriptFailure = {
 type ScriptResponse<T = object> = ScriptSuccess<T> | ScriptFailure
 type ErrorScripts = Record<string, () => ScriptFailure>
 
+type Scriptor<Args = unknown, Ret = ScriptResponse> = Pick<Function, "name" | "call"> ;
+
+/*
 type Scriptor<Args = unknown, Ret = ScriptResponse> = {
 	name: string,
 	call: (args?: Args) => Ret
 }
+*/
 
 type Subscripts =
 	Record<
@@ -49,16 +53,16 @@ interface PlayerLowsec {}
 
 interface PlayerNullsec {}
 
-type RarityString = "noob" | "kiddie" | "h4x0r" | "h4rdc0r3" | "|_|b3|2" | "31337";
-type RarityNumber = 0 | 1 | 2 | 3 | 4 | 5;
-type Rarity = RarityString | RarityNumber;
+type UpgradeRarityString = "`0noob`" | "`1kiddie`" | "`2h4x0r`" | "`3h4rdc0r3`" | "`4|_|b3|2`" | "`531337`"
+type UpgradeRarityNumber = 0 | 1 | 2 | 3 | 4 | 5;
+type UpgradeRarity = UpgradeRarityString | UpgradeRarityNumber;
 
 type UpgradeCore = {
 	name: string
 	type: "lock" | "script_space" | "chat" | "script" | "tool" | "bot_brain" | "glam"
 	up_class?: -1 | 0 | 1 | 2 | 3
 	tier: 1 | 2 | 3 | 4
-	rarity: RarityNumber
+	rarity: UpgradeRarityNumber
 	i: number
 	loaded: boolean
 	sn: string
@@ -69,7 +73,7 @@ type Upgrade = UpgradeCore & Record<string, null | boolean | number | string>
 
 type CLIUpgrade = Omit<UpgradeCore, `rarity`> & {
 	[x: string]: null | boolean | number | string
-	rarity: Rarity
+	rarity: UpgradeRarityString
 }
 
 type UsersTopItem<R> = {
@@ -245,7 +249,8 @@ type Fullsec = Subscripts & PlayerFullsec & {
 			listed_before: number
 			listed_after: number
 			cost: number | string
-		} & CLIUpgrade>) => {
+			rarity: UpgradeRarityNumber
+		} & Omit<CLIUpgrade, "rarity">>) => {
 			i: string
 			name: string
 			rarity: Upgrade["rarity"]
@@ -849,7 +854,7 @@ type Highsec = Fullsec & PlayerHighsec & {
 		}) => (
 			Omit<UpgradeCore, keyof F | `rarity`> & F & {
 				[x: string]: null | boolean | number | string
-				rarity: Rarity
+				rarity: UpgradeRarity
 			}
 		)[] | ScriptFailure)
 	}

--- a/env.d.ts
+++ b/env.d.ts
@@ -14,7 +14,7 @@ type ScriptFailure = {
 type ScriptResponse<T = object> = ScriptSuccess<T> | ScriptFailure
 type ErrorScripts = Record<string, () => ScriptFailure>
 
-type Scriptor<Args = unknown, Ret = ScriptResponse> = Pick<Function, "name" | "call"> ;
+type Scriptor = Pick<Function, "name" | "call">;
 
 /*
 type Scriptor<Args = unknown, Ret = ScriptResponse> = {

--- a/env.d.ts
+++ b/env.d.ts
@@ -231,12 +231,12 @@ type Fullsec = Subscripts & PlayerFullsec & {
 		/**
 		 * **FULLSEC**
 		 */
-		browse: ((args: {
+		browse: ((args: Partial<{
 			seller: string
 			listed_before: number
 			listed_after: number
 			cost: number | string
-		} & CLIUpgrade) => {
+		} & CLIUpgrade>) => {
 			i: string
 			name: string
 			rarity: Upgrade["rarity"]

--- a/env.d.ts
+++ b/env.d.ts
@@ -44,12 +44,16 @@ interface PlayerLowsec {}
 
 interface PlayerNullsec {}
 
+type RarityString = "noob" | "kiddie" | "h4x0r" | "h4rdc0r3" | "|_|b3|2" | "31337";
+type RarityNumber = 0 | 1 | 2 | 3 | 4 | 5;
+type Rarity = RarityString | RarityNumber;
+
 type UpgradeCore = {
 	name: string
 	type: "lock" | "script_space" | "chat" | "script" | "tool" | "bot_brain" | "glam"
 	up_class?: -1 | 0 | 1 | 2 | 3
 	tier: 1 | 2 | 3 | 4
-	rarity: 0 | 1 | 2 | 3 | 4 | 5
+	rarity: RarityNumber
 	i: number
 	loaded: boolean
 	sn: string
@@ -60,7 +64,7 @@ type Upgrade = UpgradeCore & Record<string, null | boolean | number | string>
 
 type CLIUpgrade = Omit<UpgradeCore, `rarity`> & {
 	[x: string]: null | boolean | number | string
-	rarity: "`0noob`" | "`1kiddie`" | "`2h4x0r`" | "`3h4rdc0r3`" | "`4|_|b3|2`" | "`531337`"
+	rarity: Rarity
 }
 
 type UsersTopItem<R> = {
@@ -840,7 +844,7 @@ type Highsec = Fullsec & PlayerHighsec & {
 		}) => (
 			Omit<UpgradeCore, keyof F | `rarity`> & F & {
 				[x: string]: null | boolean | number | string
-				rarity: "`0noob`" | "`1kiddie`" | "`2h4x0r`" | "`3h4rdc0r3`" | "`4|_|b3|2`" | "`531337`"
+				rarity: Rarity
 			}
 		)[] | ScriptFailure)
 	}

--- a/env.d.ts
+++ b/env.d.ts
@@ -14,6 +14,11 @@ type ScriptFailure = {
 type ScriptResponse<T = object> = ScriptSuccess<T> | ScriptFailure
 type ErrorScripts = Record<string, () => ScriptFailure>
 
+type Scriptor<Args = unknown, Ret = ScriptResponse> = {
+	name: string,
+	call: (args?: Args) => Ret
+}
+
 type Subscripts =
 	Record<
 		string,

--- a/env.d.ts
+++ b/env.d.ts
@@ -15,22 +15,15 @@ type ScriptResponse<T = object> = ScriptSuccess<T> | ScriptFailure
 type ErrorScripts = Record<string, () => ScriptFailure>
 
 type AllOptional<T> = {
-	[K in keyof T]-?: {} extends Pick<T, K> ? true : false;
-}[keyof T] extends true ? true : false;
+	[K in keyof T]-?: {} extends Pick<T, K> ? true : false
+}[keyof T]
 
 type Scriptor<Args = unknown, Ret = unknown> = {
 	name: string,
 	call: AllOptional<Args> extends true
 		? (args?: Args) => Ret
-		: (args: Args) => Ret;
-};
-
-/*
-type Scriptor<Args = unknown, Ret = ScriptResponse> = {
-	name: string,
-	call: (args?: Args) => Ret
+		: (args: Args) => Ret
 }
-*/
 
 type Subscripts =
 	Record<


### PR DESCRIPTION
Currently `market.browse` **requires** all parameters to be present, which is the inverse of what it should be. This fixes that.