### PR TITLE
Fixed: sync-macros clears all *.macros in hackmud directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
 		"golf",
 		"golfer"
 	],
+	"scripts": {
+		"build": "pnpm install",
+		"package": "bash scripts/package.sh",
+		"roolup": "bash -c ./rollup.config.js",
+		"clean": "bash -c 'rm -rf dist' && bash -c 'rm -rf node_modules'",
+		"hsm": "node dist/bin/hsm.js"
+	},
 	"homepage": "https://github.com/samualtnorman/hackmud-script-manager#readme",
 	"bugs": "https://github.com/samualtnorman/hackmud-script-manager/issues",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,6 @@
 		"golf",
 		"golfer"
 	],
-	"scripts": {
-		"build": "pnpm install",
-		"package": "bash scripts/package.sh",
-		"roolup": "bash -c ./rollup.config.js",
-		"clean": "bash -c 'rm -rf dist' && bash -c 'rm -rf node_modules'",
-		"hsm": "node dist/bin/hsm.js"
-	},
 	"homepage": "https://github.com/samualtnorman/hackmud-script-manager#readme",
 	"bugs": "https://github.com/samualtnorman/hackmud-script-manager/issues",
 	"license": "MIT",

--- a/src/syncMacros.ts
+++ b/src/syncMacros.ts
@@ -46,7 +46,7 @@ export async function syncMacros(hackmudPath: string) {
 	}
 
 	for (const user of users)
-		writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)
+		await writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)
 
 	return { macrosSynced, usersSynced: users.length }
 }

--- a/src/syncMacros.ts
+++ b/src/syncMacros.ts
@@ -45,9 +45,6 @@ export async function syncMacros(hackmudPath: string) {
 		}
 	}
 
-	//for (const user of users)
-	//	await writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)
-
 	await Promise.all(users.map(async user => writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)))
 
 	return { macrosSynced, usersSynced: users.length }

--- a/src/syncMacros.ts
+++ b/src/syncMacros.ts
@@ -45,8 +45,10 @@ export async function syncMacros(hackmudPath: string) {
 		}
 	}
 
-	for (const user of users)
-		await writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)
+	//for (const user of users)
+	//	await writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)
+
+	await Promise.all(users.map(async user => writeFile(resolvePath(hackmudPath, `${user}.macros`), macroFile)))
 
 	return { macrosSynced, usersSynced: users.length }
 }


### PR DESCRIPTION
Added fix, without "await" it was clearing macros, now it's working. Didn't test it on linux.