### PR TITLE
Fix broken build when the script contain a identifier with the same name as the script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Publish
-on: { push: { branches: [ main, "0.20" ] }, release: { types: [ created ] } }
+on: { push: { branches: [ main, "0.20" ] }, pull_request: { branches: [ "*" ] }, release: { types: [ created ] } }
 
 jobs:
   publish:

--- a/src/processScript/postprocess.ts
+++ b/src/processScript/postprocess.ts
@@ -1,5 +1,5 @@
 export const postprocess = (code: string, uniqueId: string) => code
-	.replace(/^function\s*\w+\(/, `function(`)
+	.replace(/^function\s*[\w$]+\(/, `function(`)
 	.replace(new RegExp(`\\$${uniqueId}\\$\\\\(?:\\\\)?\\$SC_DOLLAR\\$`, `g`), `S\\C$`)
 	.replace(new RegExp(`\\$${uniqueId}\\$\\\\(?:\\\\)?\\$DB_DOLLAR\\$`, `g`), `D\\B$`)
 	.replace(new RegExp(`\\$${uniqueId}\\$\\\\(?:\\\\)?\\$D\\$`, `g`), `_\\_D_S`)


### PR DESCRIPTION
Small repro to demonstrate the issue
```javascript
// source: wololo.ts
let wololo = {}

export default function() {
	return wololo
}

// compiled: wololo.js
function wololo$1(){#FMCL||(#G.wololo={})
return #G.wololo}
```

Because the `wololo` object is encoutered first when parsing the script (??), the identifier for the main function is changed to avoid the name conflict, adding a `$1` at the end.

This change is enough to bypass the regexp that strip the name during post-processing, so I just added the `$` to the relevant regexp to fix the issue.