### PR TITLE
Add better typings to `$db` functions.

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -773,22 +773,31 @@ type Projection<Schema extends object> = Partial<{
 
 
 type MongoUpdateOperators<Schema extends object> = Partial<{
-    $set: Partial<Record<string, MongoCommandValue> & Schema>;
-    $setOnInsert: Partial<Record<string, MongoCommandValue> & Schema>;
-    $unset: Partial<Record<string, ""> & Schema>;
-    $rename: Partial<Record<string, string> & Schema>;
+    $set: Partial<Record<string, MongoCommandValue> & Schema>
+    $setOnInsert: Partial<Record<string, MongoCommandValue> & Schema>
+    $unset: Partial<Record<string, ""> & Schema>
+    $rename: Partial<Record<string, string> & Schema>
 	$inc: Partial<Record<string, number> & {
-		[key in keyof Schema as Schema[key] extends number | Date ? key : never]: Schema[key] extends number ? number : Date;
-	}>;
+		[key in keyof Schema as Schema[key] extends number | Date ? key : never]: Schema[key] extends number ? number : Date
+	}>
 	$mul: Partial<Record<string, number> & {
-		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
-	}>;
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number
+	}>
 	$min: Partial<Record<string, number> & {
-		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
-	}>;
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number
+	}>
 	$max: Partial<Record<string, number> & {
-		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
-	}>;
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number
+	}>
+	$pop: Partial<Record<string, -1 | 1> & {
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: -1 | 1
+	}>
+	$push: Partial<Record<string, MongoCommandValue> & {
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorModifiers<Schema[key]>
+	}>
+	$addToSet: Partial<Record<string, MongoCommandValue> & {
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorUniversalModifiers<Schema[key]>
+	}>
 }>
 
 /*
@@ -798,12 +807,15 @@ type MongoUpdateArrayOperators<T extends Array> = {
 }
 */
 
-type MongoUpdateArrayOperatorModifiers<Schema extends Array> = {
-	$each: Schema,
-	$position: number,
-	$slice: number,
-	$sort: SortOrder | 1 | -1
-}
+type MongoUpdateArrayOperatorUniversalModifiers<T> = Partial<{
+	$each: T extends Array<infer U> ? T : T[]
+}>
+
+type MongoUpdateArrayOperatorModifiers<T> = MongoUpdateArrayOperatorUniversalModifiers<T> & Partial<{
+	$position: number
+	$slice: number
+	$sort: 1 | -1
+}>
 
 type MongoUpdateCommand<Schema extends object> = MongoUpdateOperators<Schema>
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -775,10 +775,6 @@ type Projection<Schema extends MongoSchema> = Partial<{
 	[key in keyof Schema]: boolean | 0 | 1
 }>
 
-/*
-	rename
-	addToSet
-*/
 
 type MongoUpdateOperators<Schema extends MongoSchema> = Partial<{
 	/* Universal operators */
@@ -810,7 +806,8 @@ type MongoUpdateOperators<Schema extends MongoSchema> = Partial<{
 			| MongoUpdateArrayOperatorModifiers<Schema[key]>
 	}>
 	$addToSet: Partial<Record<string, MongoCommandValue> & {
-		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorUniversalModifiers<Schema[key]>
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: (Schema[key] extends (infer U)[] ? U : never)
+			| MongoUpdateArrayOperatorUniversalModifiers<Schema[key]>
 	}>
 	$pull: Partial<Record<string, MongoCommandValue> & {
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: (Schema[key] extends (infer U)[] ? U : never)

--- a/env.d.ts
+++ b/env.d.ts
@@ -723,9 +723,13 @@ type MongoTypeString = "minKey" | "double" | "string" | "object" | "array" | "bi
 	"bool" | "date" | "null" | "regex" | "dbPointer" | "javascript" | "symbol" | "int" | "timestamp" | "long" | "decimal" | "maxKey";
 type MongoTypeNumber = -1 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 17 | 18 | 19 | 127;
 
-type MongoValue = string | number | boolean | Date | MongoValue[] | Record<string, MongoValue> | null
+type MongoValue = string | number | boolean | Date | MongoValue[] | { [key: string]: MongoValue } | null
 
-type MongoCommandValue = string | number | boolean | Date | MongoCommandValue[] | Record<string, MongoCommandValue> | null | undefined;
+type MongoCommandValue = string | number | boolean | Date | MongoCommandValue[] | { [key: string]: MongoCommandValue } | null | undefined;
+
+type MongoSchema = {
+	[key: string]: MongoValue
+}
 
 /**
  * Currently unused
@@ -763,21 +767,27 @@ type MongoQuerySelector<T extends MongoValue = MongoValue> = Partial<T extends M
 	(MongoArraySelectors<T> & MongoElementSelectors & MongoComparisonSelectors<T>) :
 	(MongoElementSelectors & MongoComparisonSelectors<T>)>
 
-type Query<Schema extends object> = Partial<{[key in keyof Schema]: MongoValue | MongoQuerySelector}> & {
+type Query<Schema extends MongoSchema> = Partial<{[key in keyof Schema]: MongoValue | MongoQuerySelector<Schema[key]>}> & {
 	_id?: Id
 };
 
-type Projection<Schema extends object> = Partial<{
+type Projection<Schema extends MongoSchema> = Partial<{
 	[key in keyof Schema]: boolean | 0 | 1
 }>
 
+/*
+	rename
+	addToSet
+*/
 
-type MongoUpdateOperators<Schema extends object> = Partial<{
+type MongoUpdateOperators<Schema extends MongoSchema> = Partial<{
 	/* Universal operators */
     $set: Partial<Record<string, MongoCommandValue> & Schema>
     $setOnInsert: Partial<Record<string, MongoCommandValue> & Schema>
     $unset: Partial<Record<string, ""> & Schema>
-    $rename: Partial<Record<string, string> & Schema>
+    $rename: Partial<Record<string, string> & {
+		[key in keyof Schema]: string
+	}>
 	/* Date & number operators */
 	$inc: Partial<Record<string, number> & {
 		[key in keyof Schema as Schema[key] extends number | Date ? key : never]: Schema[key] extends number ? number : Date
@@ -796,13 +806,15 @@ type MongoUpdateOperators<Schema extends object> = Partial<{
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: -1 | 1
 	}>
 	$push: Partial<Record<string, MongoCommandValue> & {
-		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorModifiers<Schema[key]>
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: (Schema[key] extends (infer U)[] ? U : never)
+			| MongoUpdateArrayOperatorModifiers<Schema[key]>
 	}>
 	$addToSet: Partial<Record<string, MongoCommandValue> & {
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorUniversalModifiers<Schema[key]>
 	}>
 	$pull: Partial<Record<string, MongoCommandValue> & {
-		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] extends (infer U)[] ? U : Schema[key] | MongoQuerySelector<Schema[key]>
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: (Schema[key] extends (infer U)[] ? U : never)
+			| MongoQuerySelector<Schema[key]>
 	}>
 	$pullAll: Partial<Record<string, MongoCommandValue> & {
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key]
@@ -819,7 +831,7 @@ type MongoUpdateArrayOperatorModifiers<T> = MongoUpdateArrayOperatorUniversalMod
 	$sort: 1 | -1
 }>
 
-type MongoUpdateCommand<Schema extends object> = MongoUpdateOperators<Schema>
+type MongoUpdateCommand<Schema extends MongoSchema> = MongoUpdateOperators<Schema>
 
 type Id = string | number | boolean | Date | Record<string, MongoValue>
 type MongoDocument<Schema extends object = object> = Schema & { _id: Id }
@@ -933,7 +945,7 @@ type ObjectId = { $oid: string }
 declare const $db: {
 	/** Insert a document or documents into a collection.
 	  * @param documents A document or array of documents to insert into the collection. */
-	i: <T extends object = object>(documents: (T & { _id?: Id })  | (T & { _id?: Id })[]) => {
+	i: <T extends MongoSchema = MongoSchema>(documents: (T & { _id?: Id })  | (T & { _id?: Id })[]) => {
 		ok: 1
 		n: number
 		opTime: { ts: "Undefined Conversion", t: number }
@@ -947,7 +959,7 @@ declare const $db: {
 
 	/** Remove documents from a collection.
 	  * @param query Specifies deletion criteria using query operators. */
-	r: <T extends object = object>(query: Query<T>) => {
+	r: <T extends MongoSchema = MongoSchema>(query: Query<T>) => {
 		ok: 0 | 1
 		n: number
 		opTime: { ts: "Undefined Conversion", t: number }
@@ -962,13 +974,13 @@ declare const $db: {
 	/** Find documents in a collection or view and returns a cursor to the selected documents.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param projection Specifies the fields to return in the documents that match the query filter. */
-	f: <T extends object = object>(query?: Query<T>, projection?: Projection<T>) => Cursor<MongoDocument<T>>
+	f: <T extends MongoSchema = MongoSchema>(query?: Query<T>, projection?: Projection<T>) => Cursor<MongoDocument<T>>
 
 	/** Update existing documents in a collection.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
+	u: <T extends MongoSchema = MongoSchema>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -985,7 +997,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u1: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
+	u1: <T extends MongoSchema = MongoSchema>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -1011,7 +1023,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	us: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
+	us: <T extends MongoSchema = MongoSchema>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number

--- a/env.d.ts
+++ b/env.d.ts
@@ -771,22 +771,44 @@ type Projection<Schema extends object> = Partial<{
 	[key in keyof Schema]: boolean | 0 | 1
 }>
 
-type MongoCommand<Schema extends object> = Partial<{
-	$set: Partial<Record<string, MongoCommandValue> & {
-		[K in keyof Schema]: Schema[K]
-	}>,
-	$push: Partial<Record<string, MongoCommandValue>  & {
-		[K in keyof Schema]: Schema[K]
-	}>,
-	$unset: Partial<Record<string, "">  & {
-		[K in keyof Schema]: ""
-	}>
+
+type MongoUpdateOperators<Schema extends object> = Partial<{
+    $set: Partial<Record<string, MongoCommandValue> & Schema>;
+    $setOnInsert: Partial<Record<string, MongoCommandValue> & Schema>;
+    $unset: Partial<Record<string, ""> & Schema>;
+    $rename: Partial<Record<string, string> & Schema>;
+	$inc: Partial<Record<string, number> & {
+		[key in keyof Schema as Schema[key] extends number | Date ? key : never]: Schema[key] extends number ? number : Date;
+	}>;
+	$mul: Partial<Record<string, number> & {
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
+	}>;
+	$min: Partial<Record<string, number> & {
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
+	}>;
+	$max: Partial<Record<string, number> & {
+		[key in keyof Schema as Schema[key] extends number ? key : never]: number;
+	}>;
 }>
 
+/*
+type MongoUpdateArrayOperators<T extends Array> = {
+	$pop: -1 | 1,
+	$pull: Query<T>,
+}
+*/
+
+type MongoUpdateArrayOperatorModifiers<Schema extends Array> = {
+	$each: Schema,
+	$position: number,
+	$slice: number,
+	$sort: SortOrder | 1 | -1
+}
+
+type MongoUpdateCommand<Schema extends object> = MongoUpdateOperators<Schema>
+
 type Id = string | number | boolean | Date | Record<string, MongoValue>
-type MongoDocument<Schema extends object = object> = {
-	[K in keyof Schema]: Schema[K]
-} & { _id: Id }
+type MongoDocument<Schema extends object = object> = Schema & { _id: Id }
 type SortOrder = { [key: string]: 1 | -1 | SortOrder }
 
 type Cursor<Doc extends MongoDocument = MongoDocument> = {
@@ -932,7 +954,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
+	u: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -949,7 +971,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u1: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
+	u1: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -975,7 +997,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	us: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
+	us: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoUpdateCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number

--- a/env.d.ts
+++ b/env.d.ts
@@ -763,7 +763,6 @@ type MongoQuerySelector<T extends MongoValue = MongoValue> = Partial<T extends M
 	(MongoArraySelectors<T> & MongoElementSelectors & MongoComparisonSelectors<T>) :
 	(MongoElementSelectors & MongoComparisonSelectors<T>)>
 
-//type Query = { [key: string]: MongoValue | Query } & { _id?: Id, $in?: MongoValue[] }
 type Query<Schema extends object> = Partial<{[key in keyof Schema]: MongoValue | MongoQuerySelector}> & {
 	_id?: Id
 };
@@ -933,7 +932,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u: <T extends MongoDocument = MongoDocument>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
+	u: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -976,7 +975,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	us: <T extends MongoDocument = MongoDocument>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
+	us: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number

--- a/env.d.ts
+++ b/env.d.ts
@@ -723,10 +723,9 @@ type MongoTypeString = "minKey" | "double" | "string" | "object" | "array" | "bi
 	"bool" | "date" | "null" | "regex" | "dbPointer" | "javascript" | "symbol" | "int" | "timestamp" | "long" | "decimal" | "maxKey";
 type MongoTypeNumber = -1 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 17 | 18 | 19 | 127;
 
-type MongoValue = string | number | boolean | Date | MongoValue[] | { [key: string]: MongoValue } | null
+type MongoValue = string | number | boolean | Date | MongoValue[] | Record<string, MongoValue> | null
 
-type MongoCommandValue = string | number | boolean | Date | MongoCommandValue[] | { [key: string]: MongoCommandValue } |
-null | undefined
+type MongoCommandValue = string | number | boolean | Date | MongoCommandValue[] | Record<string, MongoCommandValue> | null | undefined;
 
 /**
  * Currently unused
@@ -764,46 +763,62 @@ type MongoQuerySelector<T extends MongoValue = MongoValue> = Partial<T extends M
 	(MongoArraySelectors<T> & MongoElementSelectors & MongoComparisonSelectors<T>) :
 	(MongoElementSelectors & MongoComparisonSelectors<T>)>
 
-type Query = { [key: string]: MongoValue | Query } & { _id?: Id, $in?: MongoValue[] }
-type Projection = Record<string, boolean | 0 | 1>
+//type Query = { [key: string]: MongoValue | Query } & { _id?: Id, $in?: MongoValue[] }
+type Query<Schema extends object> = Partial<{[key in keyof Schema]: MongoValue | MongoQuerySelector}> & {
+	_id?: Id
+};
 
-type MongoCommand = MongoCommandValue & Partial<
-	{ $set: Record<string, MongoCommandValue>, $push: Record<string, MongoCommandValue>, $unset: Record<string, ""> }
->
+type Projection<Schema extends object> = Partial<{
+	[key in keyof Schema]: boolean | 0 | 1
+}>
+
+type MongoCommand<Schema extends object> = Partial<{
+	$set: Partial<Record<string, MongoCommandValue> & {
+		[K in keyof Schema]: Schema[K]
+	}>,
+	$push: Partial<Record<string, MongoCommandValue>  & {
+		[K in keyof Schema]: Schema[K]
+	}>,
+	$unset: Partial<Record<string, "">  & {
+		[K in keyof Schema]: ""
+	}>
+}>
 
 type Id = string | number | boolean | Date | Record<string, MongoValue>
-type MongoDocument = { [key: string]: MongoValue, _id: Id }
+type MongoDocument<Schema extends object = object> = {
+	[K in keyof Schema]: Schema[K]
+} & { _id: Id }
 type SortOrder = { [key: string]: 1 | -1 | SortOrder }
 
-type Cursor = {
-	/** Returns the first document that satisfies the query. */ first: () => MongoDocument | null
-	/** Returns an array of documents that satisfy the query. */ array: () => MongoDocument[]
+type Cursor<Doc extends MongoDocument = MongoDocument> = {
+	/** Returns the first document that satisfies the query. */ first: () => Doc | null
+	/** Returns an array of documents that satisfy the query. */ array: () => Doc[]
 	/** Returns the number of documents that match the query. */ count: () => number
 
 	/** Returns the first document that satisfies the query. Also makes cursor unusable. */
-	first_and_close: () => MongoDocument
+	first_and_close: () => Doc
 
 	/** Returns an array of documents that satisfy the query. Also makes cursor unusable. */
-	array_and_close: () => MongoDocument[]
+	array_and_close: () => Doc[]
 
 	/** Returns the number of documents that match the query. Also makes cursor unusable. */
 	count_and_close: () => number
 
 	/** Run `callback` on each document that satisfied the query. */
-	each: (callback: (document: MongoDocument) => void) => null
+	each: (callback: (document: Doc) => void) => null
 
 	/** Returns a new cursor with documents sorted as specified.
 	  * A value of 1 sorts the property ascending, and -1 descending.
 	  * @param order The way the documents are to be sorted. */
-	sort: (order?: SortOrder) => Cursor
+	sort: (order?: SortOrder) => Cursor<Doc>
 
 	/** Returns a new cursor without the first number of documents.
 	  * @param count Number of documents to skip. */
-	skip: (count: number) => Cursor
+	skip: (count: number) => Cursor<Doc>
 
 	/** Returns a new cursor limited to a number of documents as specified.
 	  * @param count Number of documents. */
-	limit: (count: number) => Cursor
+	limit: (count: number) => Cursor<Doc>
 
 	/** @param key The key of the documents. */ distinct: ((key: string) => MongoValue[]) & ((key: "_id") => Id[])
 	/** Make cursor unusable. */ close: () => null
@@ -883,7 +898,7 @@ type ObjectId = { $oid: string }
 declare const $db: {
 	/** Insert a document or documents into a collection.
 	  * @param documents A document or array of documents to insert into the collection. */
-	i: (documents: object | object[]) => {
+	i: <T extends object = object>(documents: (T & { _id?: Id })  | (T & { _id?: Id })[]) => {
 		ok: 1
 		n: number
 		opTime: { ts: "Undefined Conversion", t: number }
@@ -897,7 +912,7 @@ declare const $db: {
 
 	/** Remove documents from a collection.
 	  * @param query Specifies deletion criteria using query operators. */
-	r: (query: Query) => {
+	r: <T extends object = object>(query: Query<T>) => {
 		ok: 0 | 1
 		n: number
 		opTime: { ts: "Undefined Conversion", t: number }
@@ -912,13 +927,13 @@ declare const $db: {
 	/** Find documents in a collection or view and returns a cursor to the selected documents.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param projection Specifies the fields to return in the documents that match the query filter. */
-	f: (query?: Query, projection?: Projection) => Cursor
+	f: <T extends object = object>(query?: Query<T>, projection?: Projection<T>) => Cursor<T>
 
-	/** Update an existing documents in a collection.
+	/** Update existing documents in a collection.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u: (query: Query | Query[], command: MongoCommand) => {
+	u: <T extends MongoDocument = MongoDocument>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -935,7 +950,7 @@ declare const $db: {
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	u1: (query: Query | Query[], command: MongoCommand) => {
+	u1: <T extends object = object>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number
@@ -954,14 +969,14 @@ declare const $db: {
 		}
 	}
 
-	/** Update or insert or insert document.
+	/** Update or insert document.
 	  * Same as Update, but if no documents match the query, one document will be inserted based on the properties in
 	  * both the query and the command.
 	  * The `$setOnInsert` operator is useful to set defaults.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param command The modifications to apply.
 	  * {@link https://docs.mongodb.com/manual/reference/method/db.collection.update/#parameters} */
-	us: (query: Query | Query[], command: MongoCommand) => {
+	us: <T extends MongoDocument = MongoDocument>(query: Query<T> | Query<T>[], command: MongoCommand<MongoDocument<T>>) => {
 		ok: 0 | 1
 		nModified: number
 		n: number

--- a/env.d.ts
+++ b/env.d.ts
@@ -773,10 +773,12 @@ type Projection<Schema extends object> = Partial<{
 
 
 type MongoUpdateOperators<Schema extends object> = Partial<{
+	/* Universal operators */
     $set: Partial<Record<string, MongoCommandValue> & Schema>
     $setOnInsert: Partial<Record<string, MongoCommandValue> & Schema>
     $unset: Partial<Record<string, ""> & Schema>
     $rename: Partial<Record<string, string> & Schema>
+	/* Date & number operators */
 	$inc: Partial<Record<string, number> & {
 		[key in keyof Schema as Schema[key] extends number | Date ? key : never]: Schema[key] extends number ? number : Date
 	}>
@@ -789,6 +791,7 @@ type MongoUpdateOperators<Schema extends object> = Partial<{
 	$max: Partial<Record<string, number> & {
 		[key in keyof Schema as Schema[key] extends number ? key : never]: number
 	}>
+	/* Array operators */
 	$pop: Partial<Record<string, -1 | 1> & {
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: -1 | 1
 	}>
@@ -798,14 +801,13 @@ type MongoUpdateOperators<Schema extends object> = Partial<{
 	$addToSet: Partial<Record<string, MongoCommandValue> & {
 		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] | MongoUpdateArrayOperatorUniversalModifiers<Schema[key]>
 	}>
+	$pull: Partial<Record<string, MongoCommandValue> & {
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key] extends (infer U)[] ? U : Schema[key] | MongoQuerySelector<Schema[key]>
+	}>
+	$pullAll: Partial<Record<string, MongoCommandValue> & {
+		[key in keyof Schema as Schema[key] extends Array<infer U> ? key : never]: Schema[key]
+	}>
 }>
-
-/*
-type MongoUpdateArrayOperators<T extends Array> = {
-	$pop: -1 | 1,
-	$pull: Query<T>,
-}
-*/
 
 type MongoUpdateArrayOperatorUniversalModifiers<T> = Partial<{
 	$each: T extends Array<infer U> ? T : T[]
@@ -960,7 +962,7 @@ declare const $db: {
 	/** Find documents in a collection or view and returns a cursor to the selected documents.
 	  * @param query Specifies deletion criteria using query operators.
 	  * @param projection Specifies the fields to return in the documents that match the query filter. */
-	f: <T extends object = object>(query?: Query<T>, projection?: Projection<T>) => Cursor<T>
+	f: <T extends object = object>(query?: Query<T>, projection?: Projection<T>) => Cursor<MongoDocument<T>>
 
 	/** Update existing documents in a collection.
 	  * @param query Specifies deletion criteria using query operators.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"target": "ES2022",
-		"skipLibCheck": true
+		"skipLibCheck": false
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"target": "ES2022",
-		"skipLibCheck": false
+		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
This PR improves upon the existing `$db` typings, providing type safety throughout the process:

```ts
type MySchema = {
    _id: "my_schema",
    someData: number[]
}

$db.us<MySchema>({
    _id: "my_schema"
}, {
    $setOnInsert: {
        someData: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
    }
});
```