### PR TITLE
Fixes to type for `_id` in MongoDB documents return with `$db.f`

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -720,8 +720,8 @@ type MongoTypeStringsToTypes = {
 
 type MongoTypeString = keyof MongoTypeStringsToTypes
 type MongoTypeNumber = -1 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 17 | 18 | 19 | 127
-type MongoId = Exclude<MongoPrimitive, null, false> | MongoObjectId | MongoObject
-type MongoQueryId = Exclude<MongoPrimitive, null, false> | MongoObjectId | MongoQueryObject
+type MongoId = Exclude<MongoPrimitive, null | false> | MongoObjectId | MongoObject
+type MongoQueryId = Exclude<MongoPrimitive, null | false> | MongoObjectId | MongoQueryObject
 type MongoDocument = MongoObject & { _id?: MongoId }
 
 type MongoQueryType<TQuery extends MongoQueryObject> = {

--- a/env.d.ts
+++ b/env.d.ts
@@ -721,7 +721,7 @@ type MongoTypeStringsToTypes = {
 type MongoTypeString = keyof MongoTypeStringsToTypes
 type MongoTypeNumber = -1 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 17 | 18 | 19 | 127
 type MongoId = Exclude<MongoPrimitive, null, false> | MongoObjectId | MongoObject
-type MongoQueryId = Exclude<MongoPrimitive, null, false> | MongoQueryObject
+type MongoQueryId = Exclude<MongoPrimitive, null, false> | MongoObjectId | MongoQueryObject
 type MongoDocument = MongoObject & { _id?: MongoId }
 
 type MongoQueryType<TQuery extends MongoQueryObject> = {

--- a/env.d.ts
+++ b/env.d.ts
@@ -720,8 +720,8 @@ type MongoTypeStringsToTypes = {
 
 type MongoTypeString = keyof MongoTypeStringsToTypes
 type MongoTypeNumber = -1 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 16 | 17 | 18 | 19 | 127
-type MongoId = Exclude<MongoPrimitive, null> | MongoObjectId | MongoObject
-type MongoQueryId = Exclude<MongoPrimitive, null> | MongoQueryObject
+type MongoId = Exclude<MongoPrimitive, null, false> | MongoObjectId | MongoObject
+type MongoQueryId = Exclude<MongoPrimitive, null, false> | MongoQueryObject
 type MongoDocument = MongoObject & { _id?: MongoId }
 
 type MongoQueryType<TQuery extends MongoQueryObject> = {


### PR DESCRIPTION
- Removes boolean literal  `false` as a valid type for `_id`, as attempting to insert a new document with `_id:false` produces the following error:
``` :::TRUST COMMUNICATION::: can't have multiple _id fields in one document (2)```