### PR TITLE
Add pnpm v10 to supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 	},
 	"engines": {
 		"node": "^18 || >=20",
-		"pnpm": "^9"
+		"pnpm": "^9 || ^10"
 	},
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
Release notes: https://github.com/pnpm/pnpm/releases/tag/v10.0.0

Breaking changes don't seem to affect hsm at all, I have been using it all day without any issues.