### PR TITLE
Fix `this` binding in arrow functions in classes

### DIFF
--- a/src/processScript/transform.ts
+++ b/src/processScript/transform.ts
@@ -714,7 +714,11 @@ export function transform(
 						thisIsReferenced = true
 						path.replaceWith(t.identifier(`_${uniqueId}_THIS_`))
 					},
-					Function: path => path.skip()
+					Function(path) {
+						if (path.node.type != `ArrowFunctionExpression`) {
+							path.skip()
+						}
+					}
 				}, scope)
 
 				if (!methodReferencesThis)


### PR DESCRIPTION
This fixes #236. I'm not sure if there are other weird edge cases this misses, though.

```js
function(c, a) {
  class MyClass extends Object {
    constructor() {
      let _0o2iruz6j10_THIS_ = super()
      _0o2iruz6j10_THIS_.number = 2
    }
    foo() {
      let _0o2iruz6j10_THIS_ = super.valueOf()
      return [1, 2, 3].filter(n => n == _0o2iruz6j10_THIS_.number)
    }
  }
  return new MyClass()
}
```