### PR TITLE
Fix `declare` breaking babel

### DIFF
--- a/src/processScript/index.ts
+++ b/src/processScript/index.ts
@@ -184,7 +184,7 @@ export async function processScript(code: string, {
 		filePathResolved = getRelativePath(`.`, filePath)
 
 		if (filePath.endsWith(`.ts`)) {
-			plugins.push([
+			plugins.unshift([
 				(await import(`@babel/plugin-transform-typescript`)),
 				{ allowDeclareFields: true, optimizeConstEnums: true }
 			])


### PR DESCRIPTION
If the file is a typescript file, it just *appends* the typescript plugin, but it needs to be prepended, because of typescript transforms.