### PR TITLE
Fix references to `this` in default arguments of class/object methods

### DIFF
--- a/game-scripts-tests/this_array_in_object.ts
+++ b/game-scripts-tests/this_array_in_object.ts
@@ -3,7 +3,7 @@ export default ({ expect }: typeof import('vitest')) => {
 		0: `test[0]`,
 		foo: [
 			function () {
-				// @ts-ignore
+				// @ts-expect-error
 				return this[0]
 			}
 		],

--- a/game-scripts-tests/this_array_in_object.ts
+++ b/game-scripts-tests/this_array_in_object.ts
@@ -3,6 +3,7 @@ export default ({ expect }: typeof import('vitest')) => {
 		0: `test[0]`,
 		foo: [
 			function () {
+				// @ts-ignore
 				return this[0]
 			}
 		],

--- a/game-scripts-tests/this_array_in_object.ts
+++ b/game-scripts-tests/this_array_in_object.ts
@@ -3,7 +3,6 @@ export default ({ expect }: typeof import('vitest')) => {
 		0: `test[0]`,
 		foo: [
 			function () {
-				// @ts-expect-error
 				return this[0]
 			}
 		],

--- a/game-scripts-tests/this_in_default_argument.ts
+++ b/game-scripts-tests/this_in_default_argument.ts
@@ -1,6 +1,6 @@
 export default ({ expect }: typeof import('vitest')) => {
     class Foo {
-        declare foo: number;
+        declare foo: number
 
         constructor() {
             this.foo = 1
@@ -20,13 +20,13 @@ export default ({ expect }: typeof import('vitest')) => {
         bar() {
             return 2
         },
-        // @ts-ignore
+        // @ts-expect-error
         baz(a = this.foo, b = this.bar()) {
             return a + b
         }
     }
 
-    const foo = new Foo();
+    const foo = new Foo()
     expect(foo.baz(3, 4)).toBe(7) // Is this the real life?
     expect(foo.baz()).toBe(3) // Is this just fantasy?
 

--- a/game-scripts-tests/this_in_default_argument.ts
+++ b/game-scripts-tests/this_in_default_argument.ts
@@ -20,7 +20,6 @@ export default ({ expect }: typeof import('vitest')) => {
         bar() {
             return 2
         },
-        // @ts-expect-error
         baz(a = this.foo, b = this.bar()) {
             return a + b
         }

--- a/game-scripts-tests/this_in_default_argument.ts
+++ b/game-scripts-tests/this_in_default_argument.ts
@@ -1,0 +1,35 @@
+export default ({ expect }: typeof import('vitest')) => {
+    class Foo {
+        declare foo: number;
+
+        constructor() {
+            this.foo = 1
+        }
+
+        bar() {
+            return 2
+        }
+
+        baz(a = this.foo, b = this.bar()) {
+            return a + b
+        }
+    }
+
+    const obj = {
+        foo: 1,
+        bar() {
+            return 2
+        },
+        // @ts-ignore
+        baz(a = this.foo, b = this.bar()) {
+            return a + b
+        }
+    }
+
+    const foo = new Foo();
+    expect(foo.baz(3, 4)).toBe(7) // Is this the real life?
+    expect(foo.baz()).toBe(3) // Is this just fantasy?
+
+    expect(obj.baz(3, 4)).toBe(7) // Caught in a landslide
+    expect(obj.baz()).toBe(3) // No escape from reality
+}

--- a/game-scripts-tests/this_in_default_argument.ts
+++ b/game-scripts-tests/this_in_default_argument.ts
@@ -1,34 +1,35 @@
 export default ({ expect }: typeof import('vitest')) => {
-    class Foo {
-        declare foo: number
+	class Foo {
+		declare foo: number
 
-        constructor() {
-            this.foo = 1
-        }
+		constructor() {
+			this.foo = 1
+		}
 
-        bar() {
-            return 2
-        }
+		bar() {
+			return 2
+		}
 
-        baz(a = this.foo, b = this.bar()) {
-            return a + b
-        }
-    }
+		baz(a = this.foo, b = this.bar()) {
+			return a + b
+		}
+	}
 
-    const obj = {
-        foo: 1,
-        bar() {
-            return 2
-        },
-        baz(a = this.foo, b = this.bar()) {
-            return a + b
-        }
-    }
+	const obj = {
+		foo: 1,
+		bar() {
+			return 2
+		},
+		baz(a = this.foo, b = this.bar()) {
+			return a + b
+		}
+	}
 
-    const foo = new Foo()
-    expect(foo.baz(3, 4)).toBe(7) // Is this the real life?
-    expect(foo.baz()).toBe(3) // Is this just fantasy?
+	const foo = (new Foo)
 
-    expect(obj.baz(3, 4)).toBe(7) // Caught in a landslide
-    expect(obj.baz()).toBe(3) // No escape from reality
+	expect(foo.baz(3, 4)).toBe(7) // Is this the real life?
+	expect(foo.baz()).toBe(3) // Is this just fantasy?
+
+	expect(obj.baz(3, 4)).toBe(7) // Caught in a landslide
+	expect(obj.baz()).toBe(3) // No escape from reality
 }

--- a/src/processScript/transform.ts
+++ b/src/processScript/transform.ts
@@ -830,7 +830,7 @@ export function transform(
 							path.replaceWith(t.callExpression(
 								t.memberExpression(t.super(), t.identifier(`valueOf`)), []
 							))
-						},
+						}
 					}, scope)
 				}
 

--- a/src/processScript/transform.ts
+++ b/src/processScript/transform.ts
@@ -821,6 +821,19 @@ export function transform(
 
 				let methodReferencesThis = false as boolean
 
+				for (const param of classMethod.params) {
+					traverse(param, {
+						ThisExpression(path) {
+							// We can't reference _abc_THIS_ here, because there would be
+							// nowhere to place the assignment to that!
+							// Hence, we just do the super thing directly.
+							path.replaceWith(t.callExpression(
+								t.memberExpression(t.super(), t.identifier(`valueOf`)), []
+							))
+						},
+					}, scope)
+				}
+
 				traverse(classMethod.body, {
 					ThisExpression(path) {
 						methodReferencesThis = true


### PR DESCRIPTION
What the title says.

```js
function(context, args) {
  class Foo extends Object {
    constructor() {
      let _14t6uzrkvpl_THIS_ = super()
      _14t6uzrkvpl_THIS_.bar = 1
    }
    baz(a = super.valueOf().bar) {
      return a
    }
  }
  return new Foo().baz()
}
```

I did check this in-game as well, and it works :)