### PR TITLE
Replace `this` in function expressions in object properties

### DIFF
--- a/game-scripts-tests/this_in_lambda_in_object.ts
+++ b/game-scripts-tests/this_in_lambda_in_object.ts
@@ -1,0 +1,23 @@
+export default ({ expect }: typeof import('vitest')) => {
+    const myObject = {
+        a: 0,
+        b: function () {
+            this.a++
+            return this.a
+        },
+        c: function (value: number = this.a) {
+            this.a = value + 1
+        },
+        d: function ({ value = this.a }: { value?: number }) {
+            this.a = value + 1
+        }
+    }
+
+    expect(myObject.a).toBe(0)
+    myObject.b()
+    expect(myObject.a).toBe(1)
+    myObject.c()
+    expect(myObject.a).toBe(2)
+    myObject.d({})
+    expect(myObject.a).toBe(3)
+}


### PR DESCRIPTION
Fixes #256.

`hsm minify game-scripts-tests/this_in_lambda_object.ts`:

(Please note the gazillion `let`s are unrelated to this and also happened before. Opening a new issue for that)

```ts
function({ expect }) {
  let _0r9s8yrtnh2_THIS_
  let _0qaqlusuq93_THIS_
  let _09o8urfmvr2_THIS_
  let _0msk5ver1n0_THIS_
  let _12xk01szpo4_THIS_
  let _0rlmat2fi08_THIS_
  let myObject =
    (_0rlmat2fi08_THIS_ =
    _12xk01szpo4_THIS_ =
    _0msk5ver1n0_THIS_ =
    _09o8urfmvr2_THIS_ =
    _0qaqlusuq93_THIS_ =
    _0r9s8yrtnh2_THIS_ =
      {
        a: 0,
        b() {
          _0rlmat2fi08_THIS_.a++
          return _0rlmat2fi08_THIS_.a
        },
        c: function (value = _12xk01szpo4_THIS_.a) {
          _0msk5ver1n0_THIS_.a = value + 1
        },
        d: function ({ value = _09o8urfmvr2_THIS_.a }) {
          _0qaqlusuq93_THIS_.a = value + 1
        },
        f() {
          return _0r9s8yrtnh2_THIS_.a
        }
      })
  expect(myObject.a).toBe(0)
  myObject.b()
  expect(myObject.a).toBe(1)
  myObject.c()
  expect(myObject.a).toBe(2)
  myObject.d({})
  expect(myObject.a).toBe(3)
}
```